### PR TITLE
fix(ci): AppImage meebouwen in de Linux-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           - platform: ubuntu-22.04
             rust-target: x86_64-unknown-linux-gnu
             label: Linux
-            args: --bundles deb,rpm
+            args: --bundles appimage,deb,rpm
           - platform: macos-latest
             rust-target: aarch64-apple-darwin
             label: macOS (ARM)


### PR DESCRIPTION
## Probleem

De release bevat op dit moment `.deb`, `.rpm`, `.msi`, `-setup.exe` en `.dmg`, maar geen `.AppImage`. In `.github/workflows/build.yml` staat bij de `ubuntu-22.04`-regel van de build-matrix `args: --bundles deb,rpm`, wat appimage uitsluit — ook al staat `bundle.targets` in `src-tauri/tauri.conf.json` op `"all"`.

Dat is inconsistent met de rest van hetzelfde workflow-bestand:

- de artifact-upload verwijst al naar `bundle/appimage/*.AppImage`;
- de publish-stap doet al `find artifacts -name '*.AppImage'`;
- de release-notitie belooft de gebruiker al `**Linux:** \`.AppImage\` / \`.deb\` / \`.rpm\``.

Die AppImage werd dus nooit gebouwd, waardoor de belofte in de release-notitie niet klopt.

## Waarom AppImage nodig is

De OpenAEC Installer kan op Linux alleen tools installeren die een `.AppImage` in hun GitHub-release publiceren: een AppImage is een enkel bestand dat zonder root naar de home-map van de gebruiker geschreven en later weer verwijderd kan worden. Een `.deb` vereist root en pakketbeheer, wat buiten het bereik van de installer valt. Zonder AppImage is Open Calc Studio niet via de installer beschikbaar op Linux.

## Wijziging

Eén regel in `.github/workflows/build.yml`:

```diff
-            args: --bundles deb,rpm
+            args: --bundles appimage,deb,rpm
```

`.deb` en `.rpm` blijven ongewijzigd meegebouwd. Verder is er niets aangepast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
